### PR TITLE
Make the repr and pickle strings for GalsimWCS more reasonable.

### DIFF
--- a/pixmappy/GalSimWCS.py
+++ b/pixmappy/GalSimWCS.py
@@ -55,9 +55,9 @@ else:
                     pmc = PixelMapCollection(file_name)
                     if cache:
                         self.cache[file_name] = pmc
-                self._tag = 'file_name = ' + file_name
+                self._tag = 'file_name=%r'%file_name
             else:
-                self._tag = 'pmc = '+repr(pmc)
+                self._tag = 'pmc=%r'%pmc
             
             if pmc is None:
                 raise TypeError("Must provide either file_name or pmc")
@@ -148,7 +148,7 @@ else:
                     self.origin == other.origin )
 
         def __repr__(self):
-            return "galsim.GalSimWCS(%s, wcs_name=%s, origin=%r)"%(
+            return "pixmappy.GalSimWCS(%s, wcs_name=%r, origin=%r)"%(
                     self._tag, self._wcs_name, self.origin)
 
         def __hash__(self): return hash(repr(self))

--- a/pixmappy/GalSimWCS.py
+++ b/pixmappy/GalSimWCS.py
@@ -32,6 +32,10 @@ else:
                             [default: None]
         :param cache:       Cache this file's PixelMapCollection in the GalSimWCS.cache dict?
                             [default: True]
+        :param default_color:   The default color to use if this WCS involves color terms and
+                            `wcs.toWorld` or similar methods to not pass in a color term.
+                            [default: None, which means an exception will be raised if no color
+                            term is provided]
         """
         _req_params = { "file_name" : str }
         _opt_params = { "origin" : galsim.PositionD, "ccdnum": int }
@@ -42,8 +46,8 @@ else:
         cache = dict()
 
         def __init__(self, file_name=None, dir=None, pmc=None, wcs_name=None,
-                     exp=None, ccdnum=None, origin=None, cache=True):
-            self._color = None
+                     exp=None, ccdnum=None, origin=None, cache=True, default_color=None):
+            self._color = default_color
             if file_name is not None:
                 if dir is not None:
                     file_name = os.path.join(dir,file_name)
@@ -148,8 +152,12 @@ else:
                     self.origin == other.origin )
 
         def __repr__(self):
-            return "pixmappy.GalSimWCS(%s, wcs_name=%r, origin=%r)"%(
+            s = "pixmappy.GalSimWCS(%s, wcs_name=%r, origin=%r"%(
                     self._tag, self._wcs_name, self.origin)
+            if self._color is not None:
+                s += ', default_color=%r'%self._color
+            s += ')'
+            return s
 
         def __hash__(self): return hash(repr(self))
 

--- a/pixmappy/GalSimWCS.py
+++ b/pixmappy/GalSimWCS.py
@@ -153,4 +153,11 @@ else:
 
         def __hash__(self): return hash(repr(self))
 
+        def __getstate__(self):
+            # The naive pickling works, but it includes _pmc, which is huge, and not actually
+            # necessary for the functioning of the object.  (It's just for information purposes
+            # really.)  So remove it from the dict to be pickled.
+            d = self.__dict__.copy()
+            d['_pmc'] = None
+            return d
 

--- a/pixmappy/PixelMapCollection.py
+++ b/pixmappy/PixelMapCollection.py
@@ -472,9 +472,13 @@ class PixelMapCollection(object):
     def __init__(self, filename, use_pkl=True):
         '''Create PixelMapCollection from the named YAML file
 
-        If reset_pkl=True, delete any existing pkl file that may exist in the directory.
-        The default operation is to write a pickle file named `filename + '.pkl'`, which
-        significantly speeds up subsequent I/O operations on this file.
+        If use_pkl=False, this will always read in the given `filename` YAML file.
+
+        If use_pkl=True (the default), look for a pickle file named `filename + '.pkl'`,
+        to read in instead, which tends to be much faster.  If it is not there, it
+        will read in the YAML file and then write out the pkl file as a pickled version
+        of the PixelMapCollection to significantly speed up subsequent I/O operations
+        on this file.
         '''
         pkl_filename = filename + '.pkl'
         if use_pkl and  os.path.isfile(pkl_filename):

--- a/tests/test_galsim.py
+++ b/tests/test_galsim.py
@@ -216,10 +216,35 @@ def test_repr():
 
     wcs_str = str(wcs)
     wcs_repr = repr(wcs)
+    wcs_pkl = pickle.dumps(wcs)
 
     print('str(wcs) = ',wcs_str)
     print('repr(wcs) = ',wcs_repr)
     assert eval(wcs_repr) == wcs
+
+    print('pickle.dumps(wcs) has len = ',len(wcs_pkl))
+    assert len(wcs_pkl) < 1.e5
+
+    # For informational purposes to see where all the length is happening.
+    # Mostly (now that _pmc is gone) in the tree-ring template.
+    print('dict = ',wcs.__dict__.keys())
+    for k in wcs.__dict__:
+        print('wcs.%s has len %d'%(k, len(pickle.dumps(wcs.__dict__[k]))))
+    for k in wcs._wcs.__dict__:
+        print('wcs._wcs.%s has len %d'%(k, len(pickle.dumps(wcs._wcs.__dict__[k]))))
+    for k in wcs._wcs.pmap.__dict__:
+        print('wcs._wcs.pmap.%s has len %d'%(k, len(pickle.dumps(wcs._wcs.pmap.__dict__[k]))))
+    for k in wcs._wcs.pmap.elements:
+        print('wcs._wcs.pmap.elements.%s has len %d'%(k, len(pickle.dumps(k))))
+    for k in wcs._wcs.pmap.elements[0].__dict__:
+        print('wcs._wcs.pmap.elements[0].%s has len %d'%(k, len(pickle.dumps(wcs._wcs.pmap.elements[0].__dict__[k]))))
+    for k in wcs._wcs.pmap.elements[0].elements:
+        print('wcs._wcs.pmap.elements[0].elements.%s has len %d'%(k, len(pickle.dumps(k))))
+    for k in wcs._wcs.pmap.elements[0].elements[0].__dict__:
+        print('wcs._wcs.pmap.elements[0].elements[0].%s has len %d'%(k, len(pickle.dumps(wcs._wcs.pmap.elements[0].elements[0].__dict__[k]))))
+
+    assert pickle.loads(wcs_pkl) == wcs
+
 
 
 if __name__ == '__main__':

--- a/tests/test_galsim.py
+++ b/tests/test_galsim.py
@@ -203,9 +203,29 @@ def test_sky():
     np.testing.assert_almost_equal(im.array.max(), 12.506965, 5)
     np.testing.assert_almost_equal(im.array.mean(), 12.243378, 5)
 
+def test_repr():
+    """Test some things like repr, pickling, etc. to make sure they are reasonable.
+    In particular, the naive pickle string used to be extremely long.
+    """
+    try:
+        import cPickle as pickle
+    except ImportError:
+        import pickle
+
+    wcs = pixmappy.GalSimWCS(dir='input', file_name='test.astro', exp=375294, ccdnum=14)
+
+    wcs_str = str(wcs)
+    wcs_repr = repr(wcs)
+
+    print('str(wcs) = ',wcs_str)
+    print('repr(wcs) = ',wcs_repr)
+    assert eval(wcs_repr) == wcs
+
+
 if __name__ == '__main__':
     test_basic()
     test_tpv()
     test_complex()
     test_cache()
     test_sky()
+    test_repr()


### PR DESCRIPTION
I ran in to trouble using the GalSimWCS class in Piff, since the pickle string for it was crazy huge.  Turns out it was pickling up the entire Pixmappy collection, rather than just the parts it needed.

It was a simple fix to remove the `._pmc` attribute from the pickled dict, which was really only there for convenience and not needed for the operation of the WCS object.

It's still pretty long, but that's mostly because of the TreeRing template, so I think this is the best we can do here.

I also noticed and fixed some issues with the repr as well.