### PR TITLE
Y6

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ The type of mapping that can be expressed is very flexible, and `PixelMaps` can 
 
 ## DES Astrometric Solutions
 
-The `DESMaps` class derives from `PixelMapCollection` and is specialized to read astrometric solutions derived for all of the useful exposures in the Y4A1 internal data release.  Upon creation of an instance of this class, some YAML and FITS files containing WCS parameters for all these exposures are read.  The user can then request production of a `WCS` appropriate to any combination of exposure number and focal-plane detector.  Quick instructions for doing so are as follows:
+The `DESMaps` class derives from `PixelMapCollection` and is specialized to read astrometric solutions derived for all of the useful exposures in the Y6A1 internal data release.  Upon creation of an instance of this class, some YAML and FITS files containing WCS parameters for all these exposures are read.  The user can then request production of a `WCS` appropriate to any combination of exposure number and focal-plane detector.  Quick instructions for doing so are as follows:
 
 * Acquire this repository and run `python setup.py install`
-* Acquire and unpack the `y4a1_astrometry.tar.gz` file containing the solution information.
+* Acquire and unpack the `y6a1_astrometry.tar.gz` file containing the solution information.
 * Make sure that the environment variable `CAL_PATH` contains the directory into which these data were placed.
 * Run your python code!
 * Note that the color argument `c` is assumed to be _g-i_ for the DES

--- a/pixmappy/DESMaps.py
+++ b/pixmappy/DESMaps.py
@@ -71,7 +71,7 @@ class DESTweak():
             # Note that data array comes in with (y,x) indexing
             self.tweaks[detpos] = (RectBivariateSpline(xvals, yvals, hdu.data[0].transpose(),
                                                            bbox=bbox, kx=1, ky=1),
-                                   RectBivariateSpline(xvals, yvals, hdu.data[0].transpose(),
+                                   RectBivariateSpline(xvals, yvals, hdu.data[1].transpose(),
                                                            bbox=bbox, kx=1, ky=1))
         ff.close()
         return

--- a/pixmappy/DESMaps.py
+++ b/pixmappy/DESMaps.py
@@ -61,16 +61,17 @@ class DESTweak():
         for hdu in ff[1:]:
             detpos = hdu.header['EXTNAME']
             binpix = hdu.header['BINPIX']
-            nx = hdu.data.shape[1]
-            ny = hdu.data.shape[2]
+            nx = hdu.data.shape[2]
+            ny = hdu.data.shape[1]
             # Locate grid points, in 1-indexed pixel system
             xvals = binpix * np.arange(nx) + 0.5*binpix + 1
             yvals = binpix * np.arange(ny) + 0.5*binpix + 1
             bbox = [1, nx*binpix+1, 1, ny*binpix+1]
             # Create linear spline for x and y components
-            self.tweaks[detpos] = (RectBivariateSpline(xvals, yvals, hdu.data[0],
+            # Note that data array comes in with (y,x) indexing
+            self.tweaks[detpos] = (RectBivariateSpline(xvals, yvals, hdu.data[0].transpose(),
                                                            bbox=bbox, kx=1, ky=1),
-                                   RectBivariateSpline(xvals, yvals, hdu.data[0],
+                                   RectBivariateSpline(xvals, yvals, hdu.data[0].transpose(),
                                                            bbox=bbox, kx=1, ky=1))
         ff.close()
         return

--- a/pixmappy/PixelMapCollection.py
+++ b/pixmappy/PixelMapCollection.py
@@ -511,6 +511,11 @@ class PixelMapCollection(object):
     atoms = {t.type():t for t in (Identity, Constant, Linear,
                                   Polynomial, Template, Piecewise)}
 
+    # Give other code the ability to add new atomic types:
+    @classmethod
+    def addAtom(cls, newAtom):
+        cls.atoms[newAtom.type()] = newAtom
+        
     def update(self, d):
         '''Read new map/wcs specs from a supplied dictionary.  Replaces
         any duplicate names. Exception is generated if a new map or wcs

--- a/pixmappy/PixelMapCollection.py
+++ b/pixmappy/PixelMapCollection.py
@@ -472,7 +472,7 @@ class PixelMapCollection(object):
     functional realization of map with that name.  Realizations are cached so that they
     are not remade every time.
     '''
-    def __init__(self, filename=None, use_pkl=True):
+    def __init__(self, filename=None, use_pkl=False):
         '''Create PixelMapCollection from the named YAML file
 
         If use_pkl=False, this will always read in the given `filename` YAML file.
@@ -517,12 +517,12 @@ class PixelMapCollection(object):
         replaces one that has already been realized.  Dictionary will be altered
         '''
         # First check for overwrite of realized PixelMap:
-        intersect = filter(self.realizedMap.has_key, d.keys())
+        intersect = set(self.realizedMap.keys()).intersection(set(d.keys()))
         if intersect:
             raise ValueError('attempt to update already-realized PixelMaps: '+str(intersect))
         # And WCS:
         if 'WCS' in d:
-            intersect = filter(self.realizedWCS.has_key, d['WCS'].keys())
+            intersect = set(self.realizedMap.keys()).intersection(set(d['WCS'].keys()))
             if intersect:
                 raise ValueError('attempt to update already-realized WCS: '+str(intersect))
         # Proceed with updates

--- a/pixmappy/__init__.py
+++ b/pixmappy/__init__.py
@@ -2,5 +2,5 @@ from ._version import __version__, __version_info__
 
 from .files import *
 from .PixelMapCollection import *
-from .DESMaps import DESMaps,arg2detpos,DECamTweak
+from .DESMaps import DESMaps,arg2detpos,DECamTweak,Tweak
 from .GalSimWCS import *

--- a/pixmappy/__init__.py
+++ b/pixmappy/__init__.py
@@ -2,5 +2,5 @@ from ._version import __version__, __version_info__
 
 from .files import *
 from .PixelMapCollection import *
-from .DESMaps import DESMaps,arg2detpos,DESTweak
+from .DESMaps import DESMaps,arg2detpos,DECamTweak
 from .GalSimWCS import *

--- a/pixmappy/__init__.py
+++ b/pixmappy/__init__.py
@@ -2,5 +2,5 @@ from ._version import __version__, __version_info__
 
 from .files import *
 from .PixelMapCollection import *
-from .DESMaps import DESMaps
+from .DESMaps import DESMaps,arg2detpos,DESTweak
 from .GalSimWCS import *


### PR DESCRIPTION
Update for Y6A1_ASTROMETRY from full DES.  
* Dropped the ccdinfo part of DESMaps, just using all CCDs from the same zone solution for a given exposure, whichever zone had the most star matches.
* Created a Tweak class which executes two new corrections for DECam: the mean residual subtraction for each chip, plus an affine transform of each CCD fit to ~2-week intervals during DES observing.
* DESMaps inserts the tweaks into the PixelMaps by default.